### PR TITLE
remove shadowDatabaseUrl

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -6,7 +6,6 @@ const prisma = new PrismaClient({
       provider: 'postgresql',
       url: process.env.POSTGRES_PRISMA_URL,
       directUrl: process.env.POSTGRES_URL_NON_POOLING,
-      shadowDatabaseUrl: process.env.POSTGRES_URL_NON_POOLING,
     },
   },
 });


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.